### PR TITLE
fix: initialise this.logger on happy-path constructor (#6)

### DIFF
--- a/src/FbProvider.ts
+++ b/src/FbProvider.ts
@@ -45,6 +45,15 @@ export class FbProvider implements Provider {
   private _status?: ProviderStatus = ProviderStatus.NOT_READY;
   public readonly events = new OpenFeatureEventEmitter();
   constructor(options: IOptions) {
+    // Initialise the logger up-front so it is available on both the happy path
+    // and the catch block below. Without this, `this.logger` would be undefined
+    // whenever fbClient construction succeeds, and any later call that uses it
+    // (e.g. translateContext via onContextChange) would throw.
+    this.logger = options.logger ?? new BasicLogger({
+      level: options.logLevel || 'none',
+      destination: console.log
+    });
+
     try {
       this.fbClient = new FbClientBuilder({...options}).build();
       this.fbClient.on('update', (flagKeys: string[]) =>
@@ -54,11 +63,6 @@ export class FbProvider implements Provider {
       );
     } catch (err) {
       this.clientConstructionError = err;
-      this.logger = this.fbClient?.logger || (options.logger ?? new BasicLogger({
-        level: options.logLevel || 'none',
-        destination: console.log
-      }));
-
       this.logger.error(`Encountered unrecoverable initialization error, ${err}`);
       this._status = ProviderStatus.ERROR;
     }

--- a/src/translateContext.ts
+++ b/src/translateContext.ts
@@ -3,13 +3,13 @@ import { EvaluationContext } from "@openfeature/web-sdk";
 
 const builtInKeys = ["key", "name", "custom", "targetingKey"];
 
-export function translateContext(evaluationContext: EvaluationContext, logger: ILogger): IUser | undefined {
+export function translateContext(evaluationContext: EvaluationContext, logger?: ILogger): IUser | undefined {
   const custom: IContextProperty[] = (evaluationContext.custom || []) as unknown as IContextProperty[];
   const name = evaluationContext.name as string || "";
   const key: string = evaluationContext.targetingKey || evaluationContext.key as string || evaluationContext.keyId as string || '';
 
   if (key === "") {
-    logger.error(
+    logger?.error(
       "The EvaluationContext must contain either a 'targetingKey' or a 'key' or a 'keyId' and the " +
         "type must be a string."
     );

--- a/tests/FbProvider.test.ts
+++ b/tests/FbProvider.test.ts
@@ -1,0 +1,76 @@
+// Mock the underlying SDK so we can construct FbProvider in a node test
+// environment without depending on browser globals (localStorage) or network.
+jest.mock('@featbit/js-client-sdk', () => {
+  const actual = jest.requireActual('@featbit/js-client-sdk');
+
+  class FakeFbClient {
+    public logger = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    };
+    public identify = jest.fn().mockResolvedValue(undefined);
+    public on = jest.fn();
+    public close = jest.fn().mockResolvedValue(undefined);
+    public waitForInitialization = jest.fn().mockResolvedValue(undefined);
+    public boolVariation = jest.fn();
+    public stringVariation = jest.fn();
+    public numberVariation = jest.fn();
+    public jsonVariation = jest.fn();
+  }
+
+  class FakeFbClientBuilder {
+    constructor(_options?: any) {}
+    build() {
+      return new FakeFbClient();
+    }
+  }
+
+  return {
+    ...actual,
+    FbClientBuilder: FakeFbClientBuilder,
+  };
+});
+
+import { FbProvider } from '../src/FbProvider';
+
+describe('FbProvider', () => {
+  describe('onContextChange (regression: issue #6)', () => {
+    it('does not throw when the new context is missing a targeting key (happy-path construction)', async () => {
+      // Happy-path construction: previously, this left `this.logger` undefined,
+      // so the call below threw `Cannot read properties of undefined
+      // (reading 'error')` from translateContext when the new context had no
+      // targeting key.
+      const provider = new FbProvider({
+        sdkKey: 'test-sdk-key',
+        streamingUri: 'wss://example.invalid',
+        eventsUri: 'https://example.invalid',
+      } as any);
+
+      await expect(provider.onContextChange({}, {})).resolves.not.toThrow();
+    });
+
+    it('logs the missing-key error via the logger supplied in options', async () => {
+      const errorSpy = jest.fn();
+      const logger = {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: errorSpy,
+      };
+
+      const provider = new FbProvider({
+        sdkKey: 'test-sdk-key',
+        streamingUri: 'wss://example.invalid',
+        eventsUri: 'https://example.invalid',
+        logger,
+      } as any);
+
+      await provider.onContextChange({}, {});
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("'targetingKey'")
+      );
+    });
+  });
+});


### PR DESCRIPTION
Fixes #6.

## Root cause

In `FbProvider`'s constructor, `this.logger` was only assigned inside the `catch` block, so on the happy path (`fbClient` construction succeeds) it stayed `undefined`. Any subsequent code path that used it -- notably `onContextChange` -> `translateContext` -- threw `TypeError: Cannot read properties of undefined (reading 'error')` whenever the new `EvaluationContext` was missing a `targetingKey` / `key` / `keyId`. Both conditions are common in normal use of the provider with `@openfeature/web-sdk`.

## Fix

Two small, complementary changes:

1. **`src/FbProvider.ts`** -- initialise `this.logger` up-front in the constructor, before the `try` block, so it is always defined regardless of construction outcome. The previous assignment inside the `catch` block becomes redundant and is removed.
2. **`src/translateContext.ts`** -- make the `logger` parameter optional and guard the call with `?.`. Belt-and-braces against future callers that forget to pass one.

## Test

Adds `tests/FbProvider.test.ts` with a regression test that constructs `FbProvider` on the happy path and calls `onContextChange` with an empty context. The test fails on `main` (with exactly the error from the bug report) and passes with this fix. It also asserts the missing-key error is now routed through the supplied logger.

`npm test` and `npm run build` both pass locally.